### PR TITLE
Simplifies KeyValueLite initialization

### DIFF
--- a/Vapolia.KeyValueLite/Core/DataStoreName.cs
+++ b/Vapolia.KeyValueLite/Core/DataStoreName.cs
@@ -1,0 +1,7 @@
+namespace Vapolia.KeyValueLite.Core
+{
+    internal static class DataStoreName
+    {
+        public static string DbName = string.Empty;
+    }
+}

--- a/Vapolia.KeyValueLite/Core/KeyValueLite.cs
+++ b/Vapolia.KeyValueLite/Core/KeyValueLite.cs
@@ -15,12 +15,12 @@ namespace Vapolia.KeyValueLite.Core
         private readonly IKeyValueItemSerializer serializer;
 
         [Preserve(Conditional = true)]
-        public KeyValueLite(IDataStoreFactory dsFactory, IKeyValueItemSerializer serializer, ILogger logger, string appName = nameof(KeyValueLite))
+        public KeyValueLite(IDataStoreFactory dsFactory, IKeyValueItemSerializer serializer, ILogger logger)
         {
             syncer = new Syncer(logger);
             this.serializer = serializer;
          
-            var datastore = dsFactory.CreateDataStore(appName);
+            var datastore = dsFactory.CreateDataStore(DataStoreName.DbName ?? "KeyValueLite.db");
             db = new KeyValueDbContext(datastore, logger);
             KeyValueDbContext.InitDb(db);
         }

--- a/Vapolia.KeyValueLite/ServiceCollectionExtensions.cs
+++ b/Vapolia.KeyValueLite/ServiceCollectionExtensions.cs
@@ -12,25 +12,16 @@ namespace Vapolia.KeyValueLite
         {
             // Init SQLite
             Batteries_V2.Init();
-
+            DataStoreName.DbName = appName;
             // Register logger factory if not already registered
             services.AddLogging();
 
             // Register platform services and data store factory
             services.AddSingleton<IPlatformService, GenericPlatformService>();
             services.AddSingleton<IDataStoreFactory, DataStoreFactory>();
-
-
+            services.AddSingleton<IKeyValueItemSerializer, KeyValueItemSytemTextJsonSerializer>();
             // Register KeyValueLite as a singleton, resolving dependencies from DI
-            services.AddSingleton<IKeyValueLite,Core.KeyValueLite>(sp =>
-            {
-                var platformService = sp.GetRequiredService<IPlatformService>();
-                var dsFactory = new DataStoreFactory(platformService);
-                var serializer = sp.GetRequiredService<IKeyValueItemSerializer>();
-                var logger = sp.GetRequiredService<ILogger<Core.KeyValueLite>>();
-                return new Core.KeyValueLite(dsFactory, serializer, logger, appName);
-            });
-
+            services.AddSingleton<IKeyValueLite,Core.KeyValueLite>();
             services.AddSingleton<IKeyValueLiteLikeAkavache, KeyValueLiteLikeAkavache>();
 
             return services;


### PR DESCRIPTION
Refactors KeyValueLite initialization by removing the explicit app name parameter and uses DataStoreName to configure the database name.

This change simplifies the initialization process and makes it easier to manage database names.