### PR TITLE
Fixes potential null reference exceptions

### DIFF
--- a/Vapolia.KeyValueLite.Tests/TestKeyValueLite.cs
+++ b/Vapolia.KeyValueLite.Tests/TestKeyValueLite.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Vapolia.KeyValueLite.Core;
 
 namespace Vapolia.KeyValueLite.Tests
@@ -14,8 +15,8 @@ namespace Vapolia.KeyValueLite.Tests
         public void TestInit()
         {
             SQLitePCL.Batteries_V2.Init();
-            var loggerFactory = new Microsoft.Extensions.Logging.LoggerFactory();
-            var logger = loggerFactory.CreateLogger(nameof(Core.KeyValueLite));
+            var loggerFactory = new LoggerFactory();
+            var logger = loggerFactory.CreateLogger<Core.KeyValueLite>();
 
             //Clear db
             //var dbPath = dsFactory.GetDataStorePathName(nameof(KeyValueLite));

--- a/Vapolia.KeyValueLite/Core/DataStoreFactory.cs
+++ b/Vapolia.KeyValueLite/Core/DataStoreFactory.cs
@@ -19,13 +19,16 @@ namespace Vapolia.KeyValueLite.Core
 
         public virtual string GetDataStorePathName(string dataStoreName)
         {
-            switch (dataStoreName)
+            if (string.IsNullOrWhiteSpace(dataStoreName))
             {
-                case nameof(KeyValueLite):
-                    return "keyvaluecache.db";
-                default:
-                    throw new ArgumentException("Unknown data store, or not implemented", nameof(dataStoreName));
+                throw new ArgumentException("Unknown data store, or not implemented", nameof(dataStoreName));
             }
+
+            return dataStoreName switch
+            {
+                nameof(KeyValueLite) => "keyvaluecache.db",
+                _ => dataStoreName
+            };
         }
 
         protected virtual string GetDbPathNameForCurrentUser(string dbName)


### PR DESCRIPTION
Prevents potential null reference exceptions when a data store name is null or empty.

Also, injects ILogger<T> instead of ILogger to make it testable.